### PR TITLE
Fixed year from 2025 to 2026

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -154,7 +154,7 @@
         </div>
         <!-- Footer Bottom -->
         <div class="text-center text-green-100 text-xs mt-2">
-            © 2025 AI Crop Doctor. All rights reserved.
+            © 2026 AI Crop Doctor. All rights reserved.
         </div>
     </footer>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -583,7 +583,7 @@
   </div>
 <!-- Footer Bottom -->
   <div class="text-center text-green-100 text-xs mt-2">
-    © 2025 AI Crop Doctor. All rights reserved.
+    © 2026 AI Crop Doctor. All rights reserved.
   </div>
 </footer>
  <script src="{{ url_for('static', filename='js/main.js') }}"></script>


### PR DESCRIPTION
## 📌 What does this PR do?
Updates the displayed year in the footer from 2025 to 2026 to keep the site content current.

## 🔧 Changes Made
- Replaced hardcoded year `2025` with `2026` in the footer

## 🧪 How to Test
1. Run the project locally
2. Scroll to the footer
3. Verify the year displays as **2026**

## ✅ Checklist
- [x] No functional changes
- [x] UI-only update
- [x] No breaking changes
- [x] Tested locally

## 📷 Screenshots

<img width="1876" height="132" alt="image" src="https://github.com/user-attachments/assets/756d4004-eaa9-4c77-87c4-c470ced4d94c" />
<img width="1889" height="958" alt="image" src="https://github.com/user-attachments/assets/4d3fa11a-e153-4a28-8c2d-3110df6c2df9" />

This PR #21 CLOSES ISSUE #18 
